### PR TITLE
chore: add @guillaumemichel as admin to buoy

### DIFF
--- a/github/ipshipyard.yml
+++ b/github/ipshipyard.yml
@@ -119,6 +119,8 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
+      admin:
+        - guillaumemichel
       push:
         - web3-bot
     default_branch: master

--- a/github/ipshipyard.yml
+++ b/github/ipshipyard.yml
@@ -676,6 +676,8 @@ repositories:
         - SgtPooki
         - snadrus
         - ZenGround0
+      push:
+        - web3-bot
     default_branch: main
     has_discussions: false
     merge_commit_message: PR_TITLE


### PR DESCRIPTION
### Summary

Give admin access to @guillaumemichel on [buoy](https://github.com/ipshipyard/buoy)

### Why do you need this?

I am renaming `buoy` to `pulsar` and need admin access to move repo to new name

### What else do we need to know?

-

**DRI:** @guillaumemichel


### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
